### PR TITLE
Expose custom elements in the Shadow DOM

### DIFF
--- a/src/polymer-ready.js
+++ b/src/polymer-ready.js
@@ -11,7 +11,7 @@ chrome.runtime.onConnect.addListener(function(port) {
 
       case 'get-custom-elements':
         // Get all custom elements.
-        customElements = Array.prototype.slice.call(document.all).filter(function(element) {
+        customElements = Array.prototype.slice.call(document.querySelectorAll('* /deep/ *')).filter(function(element) {
           return element.localName.indexOf('-') != -1 || element.getAttribute('is');
         });
         if (customElements.length === 0) {


### PR DESCRIPTION
In our Polymer app we have a base tag `<ele-editor>` with custom elements inside the Shadow DOM. This commit exposes those elements in the popup. Thanks for the great extension!

For testing, feel free to check out https://ele.io/e
