### PR TITLE
Customelements.io for Repository Data

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,5 +27,6 @@
     "default_title": "Polymer Ready"
   },
   "permissions": [ "storage" ],
-  "manifest_version": 2
+  "manifest_version": 2,
+  "content_security_policy": "script-src 'self' https://customelementsio.herokuapp.com; object-src 'self'"
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,6 +1,7 @@
 <html>
   <body unresolved>
     <link rel="stylesheet" href="popup.css">
+    <script src="https://customelementsio.herokuapp.com"></script>
     <script src="popup.js"></script>
   </body>
 </html>


### PR DESCRIPTION
When you open up the Polymer Ready extension, there's a delay when probing for Bower components. Right now https://bower-component-list.herokuapp.com is returning a `418 I'm a teapot` status code and hasn't been 100% reliable in the past. I propose we switch over to [Customelements.io](http://customelements.io/) to reduce requests and make the extension super fast. All of the core and paper elements are already on there.

After switching over I've noticed significant performance improvements. It's nearly instant now!