### PR TITLE
Fixed extension to work with current versions of Chrome.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Polymer Ready",
   "description": "Show an icon in the address bar when it detects some Polymer and Custom components.",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "icons": {
     "128": "assets/icon128.png"
   },

--- a/src/popup.css
+++ b/src/popup.css
@@ -14,6 +14,11 @@ hr {
   border: 0;
 }
 
+body {
+  min-width: 5%;
+  min-height: 100%
+}
+
 .el {
   white-space: nowrap;
   line-height: 28px;


### PR DESCRIPTION
Changed code to find all custom elements from from using the deep combinator, since it had been deprecated in Chrome, to use querySelectorAll('*') as per the example in https://developers.google.com/web/fundamentals/getting-started/primers/shadowdom#findall. Bumped version number in manifest.