### PR TITLE
To fix #15 to show the name of Extending Custom Elements

### DIFF
--- a/src/polymer-ready.js
+++ b/src/polymer-ready.js
@@ -50,7 +50,7 @@ chrome.runtime.onConnect.addListener(port => {
           originalBackgroundColor[i] = el.style.backgroundColor;
         });
         // Send unique sorted custom elements localName to popup.js.
-        const customElementsNames = allCustomElements.map(el => el.localName)
+        const customElementsNames = allCustomElements.map(el => el.localName.includes('-') && el.localName || `${el.getAttribute('is')} (${el.localName})`)
             .sort().filter((el, i, a) => i === a.indexOf(el));
         port.postMessage({ customElements: customElementsNames });
         break;


### PR DESCRIPTION
@beaufortfrancois @abdonrd 

To fix #15. PTAL.

Now the Extending CE will show `dom-repeat (template)` instead of `template`.